### PR TITLE
Arrumando a cobertura de testes no backend

### DIFF
--- a/scripts/clean_test.py
+++ b/scripts/clean_test.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for scripts/clean_test.py."""
+"""Unit tests for scripts/st.py."""
 
 from __future__ import annotations
 

--- a/scripts/start_test.py
+++ b/scripts/start_test.py
@@ -116,7 +116,7 @@ class StartTests(test_utils.GenericTestBase):
         self.swap_mock_set_constants_to_default = self.swap(
             common, 'set_constants_to_default', mock_constants)
 
-    def test_start_servers_successfully(self) -> None:
+    def test_start_successfully(self) -> None:
         with self.swap_install_third_party_libs:
             from scripts import start
         swap_build = self.swap_with_checks(
@@ -145,7 +145,7 @@ class StartTests(test_utils.GenericTestBase):
             ],
             self.print_arr)
 
-    def test_start_servers_successfully_in_production_mode(self) -> None:
+    def test_start_successfully_in_production_mode(self) -> None:
         with self.swap_install_third_party_libs:
             from scripts import start
         swap_build = self.swap_with_checks(
@@ -173,7 +173,7 @@ class StartTests(test_utils.GenericTestBase):
             ],
             self.print_arr)
 
-    def test_start_servers_successfully_in_maintenance_mode(self) -> None:
+    def test_start_successfully_in_maintenance_mode(self) -> None:
         with self.swap_install_third_party_libs:
             from scripts import start
         swap_build = self.swap_with_checks(


### PR DESCRIPTION
## Overview

1. Esta PR Conserta a Issue #6.
2. Esta PR estabelece que: O conserto da variavel `uncovered_lines` na linha 51 do arquivo `check_overall_backend_test_coverage.py`